### PR TITLE
Remove redundant AuthProvider in root layout

### DIFF
--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import AuthProvider from "@/app/providers/SessionProvider";
 import "@/app/globals.css";
 import Navbar from "@/app/components/navbar";
 
@@ -15,10 +14,8 @@ export default function GroupLayout({
 }) {
   return (
     <>
-      <AuthProvider>
-        <Navbar />
-        {children}
-      </AuthProvider>
+      <Navbar />
+      {children}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- simplify `(root)` layout and use `AuthProvider` only in `app/layout.tsx`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ca257b5c832fa9820152709cc5d7