### PR TITLE
Fix custom Tailwind utility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,16 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@layer utilities {
+  .heading {
+    @apply uppercase bg-black px-6 py-3 font-work-sans font-extrabold text-white
+      text-[36px] leading-[46px] max-w-5xl text-center;
+  }
+
+  @screen sm {
+    .heading {
+      @apply text-[54px] leading-[64px];
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define a custom `.heading` utility in `globals.css`
- include responsive styles without breaking Tailwind's build

## Testing
- `npm run lint` *(fails: 403 Forbidden for `next`)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ce6f3bcc832f8f9218e613fedb8b