### PR TITLE
Add author and startup schemas

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -2,13 +2,12 @@
 
 import { visionTool } from '@sanity/vision'
 import { defineConfig } from 'sanity'
-// ❌ REMOVE structureTool import
 // import { structureTool } from 'sanity/structure'
 
 import { apiVersion, dataset, projectId } from './sanity/env'
 import { schema } from './sanity/schemaTypes'
-// ❌ Optional: remove this too if you're not using custom structure yet
-// import { structure } from './sanity/structure'
+import { structure } from './sanity/structure'
+import { markdownSchema } from 'sanity-plugin-markdown'
 
 export default defineConfig({
   basePath: '/studio',
@@ -16,7 +15,8 @@ export default defineConfig({
   dataset,
   schema,
   plugins: [
-    // ❌ REMOVE structureTool
+    // structureTool({ structure }),
     visionTool({ defaultApiVersion: apiVersion }),
+    markdownSchema(),
   ],
 })

--- a/sanity/schemaTypes/author.ts
+++ b/sanity/schemaTypes/author.ts
@@ -1,0 +1,40 @@
+import { defineField, defineType } from "sanity";
+import { UserIcon } from "lucide-react";
+
+export const author = defineType({
+  name: "author",
+  title: "Author",
+  type: "document",
+  icon: UserIcon,
+  fields: [
+    defineField({
+      name: "id",
+      type: "number",
+    }),
+    defineField({
+      name: "name",
+      type: "string",
+    }),
+    defineField({
+      name: "username",
+      type: "string",
+    }),
+    defineField({
+      name: "email",
+      type: "string",
+    }),
+    defineField({
+      name: "image",
+      type: "url",
+    }),
+    defineField({
+      name: "bio",
+      type: "text",
+    }),
+  ],
+  preview: {
+    select: {
+      title: "name",
+    },
+  },
+});

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -1,5 +1,8 @@
 import { type SchemaTypeDefinition } from 'sanity'
 
+import { author } from './author'
+import { startup } from './startup'
+
 export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [],
+  types: [author, startup],
 }

--- a/sanity/schemaTypes/startup.ts
+++ b/sanity/schemaTypes/startup.ts
@@ -1,0 +1,48 @@
+import { defineField, defineType } from "sanity";
+
+export const startup = defineType({
+  name: "startup",
+  title: "Startup",
+  type: "document",
+  fields: [
+    defineField({
+      name: "title",
+      type: "string",
+    }),
+    defineField({
+      name: "slug",
+      type: "slug",
+      options: {
+        source: "title",
+      },
+    }),
+    defineField({
+      name: "author",
+      type: "reference",
+      to: { type: "author" },
+    }),
+    defineField({
+      name: "views",
+      type: "number",
+    }),
+    defineField({
+      name: "description",
+      type: "text",
+    }),
+    defineField({
+      name: "category",
+      type: "string",
+      validation: (Rule) =>
+        Rule.min(1).max(20).required().error("Please enter a category"),
+    }),
+    defineField({
+      name: "image",
+      type: "url",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "pitch",
+      type: "markdown",
+    }),
+  ],
+});

--- a/sanity/structure.ts
+++ b/sanity/structure.ts
@@ -1,7 +1,10 @@
-import type {StructureResolver} from 'sanity/structure'
+import type { StructureResolver } from 'sanity/structure'
 
 // https://www.sanity.io/docs/structure-builder-cheat-sheet
 export const structure: StructureResolver = (S) =>
   S.list()
     .title('Content')
-    .items(S.documentTypeListItems())
+    .items([
+      S.documentTypeListItem('author').title('Authors'),
+      S.documentTypeListItem('startup').title('Startups'),
+    ])


### PR DESCRIPTION
## Summary
- implement `author` schema
- implement `startup` schema
- register new schema types and adjust structure builder
- enable markdown plugin in Sanity config

## Testing
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685503151378832fb377935f66f62cc1